### PR TITLE
Fixing DEVELOPING.md

### DIFF
--- a/api/DEVELOPING.md
+++ b/api/DEVELOPING.md
@@ -4,6 +4,7 @@ We use Flask as an API for the expo app. It mainly interfaces with the database,
 
 # General Guidelines / Tips
 
+* Make sure to be using Python 3!
 * Make sure your code follows [PEP8](https://www.python.org/dev/peps/pep-0008/).
 * Try to keep features in their own file, i.e. any database access should go through db.py
 * Flask has patterns on their [website](http://flask.pocoo.org/docs/1.0/patterns/). We don't strictly follow these, but they're good to keep in mind.

--- a/api/DEVELOPING.md
+++ b/api/DEVELOPING.md
@@ -13,21 +13,21 @@ We use Flask as an API for the expo app. It mainly interfaces with the database,
 
 # Setup
 ## Virtualenv
-We use virtualenv. To install on Linux/MacOS, run `sudo pip install virtualenv` and then run `virtualenv venv`. To use it, cd into this directory and run `source venv/bin/activate` on Linux/MacOS or `.\venv\Scripts\activate` on Windows.
+We use virtualenv. To install on Linux/MacOS, make sure you have `python3`, `python3-pip`, and `python3-venv` are installed. Run `python3 -m venv venv` to create a virtual environment called `venv` in this directory. To use it, cd into this directory and run `source venv/bin/activate` on Linux/MacOS or `.\venv\Scripts\activate` on Windows.
 
 Run `deactivate` to exit the virtual environment.
 
 ## Installation
-Once in the virtualenv, run `pip install -r requirements.txt`. This installs the required packages.
+Once in the virtualenv, run `pip3 install -r requirements.txt`. This installs the required packages.
 
 # Running
-To run the server, just run `python server.py`. The Flask server is then accessible from http://127.0.0.1:5000/.
+To run the server, just run `python3 server.py`. The Flask server is then accessible from http://127.0.0.1:5000/.
 
 # Developing
 The server file is separated out into database, public, and private CRUD routes. When adding endpoints, make sure it goes into the right section. If you need to create a new section, please feel free to.
 
 ## Adding packages
-To install new packages, just run `pip install <package>`, and then to save it, run `pip freeze > requirements.txt`
+To install new packages, just run `pip3 install <package>`, and then to save it, run `pip3 freeze > requirements.txt`
 
 # Testing
 [Coming soon]

--- a/api/DEVELOPING.md
+++ b/api/DEVELOPING.md
@@ -6,7 +6,7 @@ We use Flask as an API for the expo app. It mainly interfaces with the database,
 
 * Make sure your code follows [PEP8](https://www.python.org/dev/peps/pep-0008/).
 * Try to keep features in their own file, i.e. any database access should go through db.py
-* Flask has patterns on their [website](http://flask.pocoo.org/docs/0.12/patterns/). We do'nt strictly follow these, but they're good to keep in mind.
+* Flask has patterns on their [website](http://flask.pocoo.org/docs/0.12/patterns/). We don't strictly follow these, but they're good to keep in mind.
 * Write tests! More on this further down!
 
 

--- a/api/DEVELOPING.md
+++ b/api/DEVELOPING.md
@@ -6,7 +6,7 @@ We use Flask as an API for the expo app. It mainly interfaces with the database,
 
 * Make sure your code follows [PEP8](https://www.python.org/dev/peps/pep-0008/).
 * Try to keep features in their own file, i.e. any database access should go through db.py
-* Flask has patterns on their [website](http://flask.pocoo.org/docs/0.12/patterns/). We don't strictly follow these, but they're good to keep in mind.
+* Flask has patterns on their [website](http://flask.pocoo.org/docs/1.0/patterns/). We don't strictly follow these, but they're good to keep in mind.
 * Write tests! More on this further down!
 
 


### PR DESCRIPTION
Fixed a typo and updated a link -- we ought to refer to the Flask 1.0 docs if we're using [Flask 1.0.2](https://github.com/gotechnica/technica-expo-app/blob/master/api/requirements.txt) ;)

Also updated Python-relevant instructions to be using Python 3, as per approval by @timothychen01. Any old virtual environments can be safely nuked with a good ol' `rm -rf venv/` to make room for a Python 3 based one.