### PR TITLE
api: added sponsor credential endpoints

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,8 +1,11 @@
+bcrypt==3.1.4
 certifi==2018.8.24
+cffi==1.11.5
 chardet==3.0.4
 click==6.7
 Flask==1.0.2
 Flask-Cors==3.0.6
+Flask-Login==0.4.1
 Flask-PyMongo==0.5.2
 get==1.0.3
 idna==2.7
@@ -11,6 +14,7 @@ Jinja2==2.10
 MarkupSafe==1.0
 post==1.0.2
 public==1.0.3
+pycparser==2.19
 pymongo==3.6.1
 query-string==1.0.2
 requests==2.19.1

--- a/api/server.py
+++ b/api/server.py
@@ -9,6 +9,7 @@ import json
 import hashlib
 import io
 from seed_db import *
+import bcrypt
 
 app = Flask(__name__)
 CORS(app)
@@ -49,6 +50,36 @@ def get_project(project_id):
     project_obj = projects.find_one({'_id': ObjectId(project_id)})
     return json.dumps(project_obj, default=json_util.default)
 
+
+@app.route('/api/add_sponsor_credential', methods=['POST'])
+def add_sponsor_credential():
+    credential = mongo.db.sponsor_credentials
+
+    company = request.json['company']
+    access_code = request.json['access_code'].encode('utf-8')
+    access_code = bcrypt.hashpw(access_code, bcrypt.gensalt()).decode('utf-8')
+
+    temp_credential = {
+        'company': company,
+        'access_hash': access_code
+    }
+
+    credential.insert(temp_credential)
+    return 'Inserted {}'.format(company)
+
+
+@app.route('/api/verify_sponsor_credential', methods=['POST'])
+def verify_sponsor_credential():
+    credential = mongo.db.sponsor_credentials
+
+    recv_access_code = request.json['access_code'].encode('utf-8')
+
+    for sc in credential.find():
+        db_hash = sc['access_hash'].encode('utf-8')
+        if bcrypt.checkpw(recv_access_code, db_hash):
+            return 'Hello {}!'.format(sc['company'])
+
+    return 'No company found'
 
 # Admin routes #################################################################
 # All endpoints under the Admin routes should require admin authorization.


### PR DESCRIPTION
Added two endpoints:
* `/api/add_sponsor_credential`: accepts a POST with a JSON containing a
  `company` and `access_code`. Hashes the access code with bcrypt and
  stores it.
* `/api/verify_sponsor_credential`: accepts a POST request with a JSON
  containing an `access_code`. Checks the hash of the given access code
  against all company credentials in the db, and returns the company if
  there's a match.

These probably should be moved to a different section within the file to denote the access control level of the endpoints, but I wasn't sure where to put them.

Incorporating sessions/logins with these should probably be all that's needed for the sponsors