### PR TITLE
Fix CSV upload input/button

### DIFF
--- a/expo/src/Admin.css
+++ b/expo/src/Admin.css
@@ -95,3 +95,17 @@
 .m-r-m {
   margin-right: 1rem;
 }
+
+.upload-btn-wrapper {
+  position: relative;
+  overflow: hidden;
+  display: inline-block;
+}
+
+.upload-btn-wrapper input[type=file] {
+  font-size: 100px;
+  position: absolute;
+  left: 0;
+  top: 0;
+  opacity: 0;
+}

--- a/expo/src/Admin.css
+++ b/expo/src/Admin.css
@@ -78,7 +78,11 @@
   margin-left: 1em;
 }
 
-.upload_icon{
+.font-weight-normal {
+  font-weight: normal;
+}
+
+.upload_icon {
   margin-right: 0.6rem;
 }
 

--- a/expo/src/Admin.js
+++ b/expo/src/Admin.js
@@ -50,7 +50,8 @@ class ProjectModule extends Component {
         {project_name: 'peaches', table_number: '7',url:'www.hello.com',challenge_name:'challenge1'},
         {project_name: 'small', table_number: '9',url:'www.hello.com',challenge_name:'challenge1'},
       ],
-      uploadStatus: '',
+      projectsCSV:'',
+      uploadStatus:'',
       tableAssignmentStatus: '',
       tableAssignmentSchema: '',
       tableStartLetter: '',
@@ -113,19 +114,19 @@ class ProjectModule extends Component {
         uploadStatus: 'Please select a file before hitting upload!'
       });
     } else {
-      axios.post(`${Backend.URL}parse_csv`, data)
+      axios.post(`${Backend.httpFunctions.url}parse_csv`, data)
+        .then((response) => {
+          this.projects_csv.value = ''; // Clear input field
+          this.setState({ // Flash success message and clear input display
+            uploadStatus: response.data,
+            projectsCSV: ''
+          });
+        })
         .catch((error) => {
           this.setState({ // Flash error message
             uploadStatus: 'Oops! Something went wrong...'
           });
           console.error('Error:', error);
-        })
-        .then((response) => {
-          this.projects_csv.value = ''; // Clear input field
-          this.setState({ // Flash success message
-            uploadStatus: response.data
-          });
-          return response.text();
         });
     }
 	}
@@ -222,9 +223,12 @@ class ProjectModule extends Component {
             onSubmit={this.onUploadCSVSubmitForm.bind(this)}
           >
             <div className="form-group">
-              <label>Upload CSV for parsing</label>
-              <input type="file" id="file" className="inputfile" name="projects_csv" ref={(ref) => { this.projects_csv = ref; }} />
-              <label><FontAwesomeIcon icon="upload" className="upload_icon"></FontAwesomeIcon>Choose a file</label>
+              <label>Upload Devpost CSV for parsing</label><br/>
+              <div className="upload-btn-wrapper">
+                <button className="button button-primary m-r-m"><FontAwesomeIcon icon="upload" className="upload_icon"></FontAwesomeIcon>Choose a file</button>
+                <input type="file" id="file" name="projectsCSV" onChange={this.handleInputChange.bind(this)} ref={(ref) => { this.projects_csv = ref; }} />
+                {this.state.projectsCSV.replace("C:\\fakepath\\", "")}
+              </div>
             </div>
             <button className="button button-primary" type="submit">Upload</button>
             {this.state.uploadStatus != '' &&

--- a/expo/src/Admin.js
+++ b/expo/src/Admin.js
@@ -143,6 +143,12 @@ class ProjectModule extends Component {
 
   onAutoAssignTableNumbers(e) {
     e.preventDefault();
+    if (this.state.tableAssignmentSchema == '') {
+      this.setState({
+        tableAssignmentStatus: 'Please first select a schema for assigning table numbers.',
+      });
+      return;
+    }
     this.setState({
       tableAssignmentStatus: 'Processing your request to assign table numbers...',
     });

--- a/expo/src/Admin.js
+++ b/expo/src/Admin.js
@@ -225,7 +225,7 @@ class ProjectModule extends Component {
             <div className="form-group">
               <label>Upload Devpost CSV for parsing</label><br/>
               <div className="upload-btn-wrapper">
-                <button className="button button-primary m-r-m"><FontAwesomeIcon icon="upload" className="upload_icon"></FontAwesomeIcon>Choose a file</button>
+                <button className="button button-primary font-weight-normal m-r-m"><FontAwesomeIcon icon="upload" className="upload_icon"></FontAwesomeIcon>Choose a file</button>
                 <input type="file" id="file" name="projectsCSV" onChange={this.handleInputChange.bind(this)} ref={(ref) => { this.projects_csv = ref; }} />
                 {this.state.projectsCSV.replace("C:\\fakepath\\", "")}
               </div>

--- a/expo/src/Backend.js
+++ b/expo/src/Backend.js
@@ -2,7 +2,7 @@ const backendDevURL = 'http://localhost:5000/';
 const devURL = 'http://ec2-34-201-45-125.compute-1.amazonaws.com/';
 const prodURL = '';
 
-const URL = devURL;
+const URL = backendDevURL;
 
 // Use the following functions to use post and get requests
 let httpFunctions = {


### PR DESCRIPTION
The existing styled input couldn't actually select any files.

This PR:
- Uses a CSS hack to hide input and use a styled button instead
- Adds a display for the current file selected (added this variable to state) - (looks weird if super long file name, but ehhh for now)
- Exports URL from Backend.js to make URL available (can't use existing API call methods for special file case)

![image](https://user-images.githubusercontent.com/14797288/46999888-c832fc80-d0db-11e8-9857-f04cbea4d75c.png)
