### PR TITLE
Reduce spacing between challenges on web, maintain spacing on mobile

### DIFF
--- a/expo/src/Table.css
+++ b/expo/src/Table.css
@@ -86,11 +86,6 @@
   padding-left: 20px;
 }
 
-#Home div.challenges-won,
-#Home div.attempted-challenges {
-  padding: 7px 0px 0px 0px;
-}
-
 #Home div.challenges-won div {
   margin-right: 10px;
 }
@@ -98,7 +93,6 @@
 #Home div.attempted-challenges button {
   color: #999999;
   font-size: 17px;
-  margin-bottom: 5px;
   padding: 0px;
 }
 
@@ -135,15 +129,18 @@
   #Home div.challenges-won div {
     margin-right: 0px;
   }
-  #Home div.attempted-challenges button {
-    text-align: center;
-  }
   #Sponsor table tbody tr td div.Project,
   #Home table tbody tr td div.Project {
     font-size: 20px;
   }
   #Home div.attempted-challenges button {
+    text-align: center;
     font-size: 15px;
+    margin-bottom: 5px;
+  }
+  #Home div.challenges-won,
+  #Home div.attempted-challenges {
+    padding: 7px 0px 0px 0px;
   }
 }
 

--- a/expo/src/Table.js
+++ b/expo/src/Table.js
@@ -132,7 +132,9 @@ class ProjectColumn extends Component {
         </div>
         { this.props.origin === "home" ?
           <Fragment>
-            <div className="challenges-won">{challenges_won}</div>
+            {challenges_won.length > 0 &&
+              <div className="challenges-won">{challenges_won}</div>
+            }
             { attempted_challenges.length > 0 ?
               <Fragment>
                 { this.props.width < 460 ? <hr className="attempted-challenges"/> : <Fragment></Fragment> }


### PR DESCRIPTION
# Web (Not showing challenges)
### Before
![image](https://user-images.githubusercontent.com/14797288/47771007-cf8f0400-dc9e-11e8-93f8-2b1ac26b0385.png)

### After
![image](https://user-images.githubusercontent.com/14797288/47770897-69a27c80-dc9e-11e8-86f7-356269fbbf3b.png)


# Web (Showing challenges)
### Before
![image](https://user-images.githubusercontent.com/14797288/47771017-d7e73f00-dc9e-11e8-9cf7-99c811c3a27d.png)


### After
![image](https://user-images.githubusercontent.com/14797288/47770893-627b6e80-dc9e-11e8-9823-111e979baf0f.png)




# Mobile
### (looks the same before/after for both because media queries)
![image](https://user-images.githubusercontent.com/14797288/47770790-06184f00-dc9e-11e8-91cc-6c5a43ab5876.png)

![image](https://user-images.githubusercontent.com/14797288/47770776-fa2c8d00-dc9d-11e8-9dbb-4c5277491edd.png)