### PR TITLE
Convert to absolute imports for react app

### DIFF
--- a/expo/.env
+++ b/expo/.env
@@ -1,0 +1,1 @@
+NODE_PATH=src/

--- a/expo/src/Admin.css
+++ b/expo/src/Admin.css
@@ -1,4 +1,4 @@
-@import url('./customize/customize.css');
+@import url('customize/customize.css');
 
 h4 {
   font-weight: bold;

--- a/expo/src/Admin.js
+++ b/expo/src/Admin.js
@@ -1,27 +1,27 @@
 import React, { Component } from 'react';
-import axiosRequest from './Backend.js';
+import axiosRequest from 'Backend.js';
 
-import CreateChallengeModal from './admin/CreateChallengeModal';
-import CreateProjectModal from './admin/CreateProjectModal';
-import CreateSponsorModal from './admin/CreateSponsorModal';
-import EditChallengeModal from './admin/EditChallengeModal';
-import EditProjectModal from './admin/EditProjectModal';
-import EditSponsorModal from './admin/EditSponsorModal';
-import WarningModal from './admin/WarningModal';
-import SubmitInputModal from './components/SubmitInputModal';
+import CreateChallengeModal from 'admin/CreateChallengeModal';
+import CreateProjectModal from 'admin/CreateProjectModal';
+import CreateSponsorModal from 'admin/CreateSponsorModal';
+import EditChallengeModal from 'admin/EditChallengeModal';
+import EditProjectModal from 'admin/EditProjectModal';
+import EditSponsorModal from 'admin/EditSponsorModal';
+import WarningModal from 'admin/WarningModal';
+import SubmitInputModal from 'components/SubmitInputModal';
 
-import './Admin.css';
-import './App.css';
-import { sortByTableNumber } from './helpers.js';
-import WinnerBadge from './customize/imgs/winner_ribbon.png';
+import 'Admin.css';
+import 'App.css';
+import { sortByTableNumber } from 'helpers.js';
+import WinnerBadge from 'customize/imgs/winner_ribbon.png';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import SiteWrapper from './SiteWrapper.js';
-import SmallerParentheses from './SmallerParentheses.js';
+import SiteWrapper from 'SiteWrapper.js';
+import SmallerParentheses from 'SmallerParentheses.js';
 
 import { library } from '@fortawesome/fontawesome-svg-core';
-import { faSquare } from '../node_modules/@fortawesome/fontawesome-free-regular';
-import { faCaretDown, faCaretUp, faCheckSquare, faUpload } from '../node_modules/@fortawesome/fontawesome-free-solid';
+import { faSquare } from '@fortawesome/fontawesome-free-regular';
+import { faCaretDown, faCaretUp, faCheckSquare, faUpload } from '@fortawesome/fontawesome-free-solid';
 library.add(faUpload);
 library.add(faCaretDown);
 library.add(faCaretUp);

--- a/expo/src/AdminLogin.js
+++ b/expo/src/AdminLogin.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
-import axiosRequest from './Backend.js';
+import axiosRequest from 'Backend.js';
 
-import Error from './Error.js';
-import Login from './Login.js';
-import SiteWrapper from './SiteWrapper.js';
+import Error from 'Error.js';
+import Login from 'Login.js';
+import SiteWrapper from 'SiteWrapper.js';
 
-import './App.css';
+import 'App.css';
 
 
 const InvalidErr = <Error text="Invalid login code!" />;

--- a/expo/src/App.css
+++ b/expo/src/App.css
@@ -1,4 +1,4 @@
-@import url('./customize/customize.css');
+@import url('customize/customize.css');
 
 html {
   background-color: var(--app_background_color);

--- a/expo/src/App.js
+++ b/expo/src/App.js
@@ -1,15 +1,15 @@
 import React from 'react';
 import { BrowserRouter as Router, Route, Redirect } from 'react-router-dom';
-import { useCachedResponseData } from './Backend.js';
+import { useCachedResponseData } from 'Backend.js';
 
-import '../node_modules/bootstrap/dist/css/bootstrap.min.css';
-import './App.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'App.css';
 
-import Admin from './Admin.js';
-import AdminLogin from './AdminLogin.js';
-import Home from './Home.js';
-import Sponsor from './Sponsor.js';
-import SponsorLogin from './SponsorLogin.js';
+import Admin from 'Admin.js';
+import AdminLogin from 'AdminLogin.js';
+import Home from 'Home.js';
+import Sponsor from 'Sponsor.js';
+import SponsorLogin from 'SponsorLogin.js';
 
 
 /* Routing control for app overall */

--- a/expo/src/Backend.js
+++ b/expo/src/Backend.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
-import projectData from './responseData/projects.json';
-import challengeData from './responseData/challenges.json';
+import projectData from 'responseData/projects.json';
+import challengeData from 'responseData/challenges.json';
 
 const backendDevURL = 'http://localhost:8000/';
 //const prodURL = 'https://expo-api.bit.camp/';

--- a/expo/src/CircleCheck.css
+++ b/expo/src/CircleCheck.css
@@ -1,4 +1,4 @@
-@import url('./customize/customize.css');
+@import url('customize/customize.css');
 
 .checkmark__circle {
   stroke-dasharray: 166;

--- a/expo/src/Error.js
+++ b/expo/src/Error.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
-import { FontAwesomeIcon } from '../node_modules/@fortawesome/react-fontawesome';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-import { faExclamationTriangle } from '../node_modules/@fortawesome/fontawesome-free-solid';
-import { library } from '../node_modules/@fortawesome/fontawesome-svg-core';
+import { faExclamationTriangle } from '@fortawesome/fontawesome-free-solid';
+import { library } from '@fortawesome/fontawesome-svg-core';
 library.add(faExclamationTriangle);
 
 

--- a/expo/src/Home.js
+++ b/expo/src/Home.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import SearchandFilter from './SearchandFilter';
-import SiteWrapper from './SiteWrapper.js';
+import SearchandFilter from 'SearchandFilter';
+import SiteWrapper from 'SiteWrapper.js';
 
-import './App.css';
+import 'App.css';
 
 
 export default class Home extends React.Component {

--- a/expo/src/Login.js
+++ b/expo/src/Login.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import Card from './components/Card.js'
+import Card from 'components/Card.js'
 
 /*
 Generic login component for Admins and Sponsors

--- a/expo/src/SearchandFilter.js
+++ b/expo/src/SearchandFilter.js
@@ -1,13 +1,13 @@
 import React, { Component, Fragment } from 'react';
-import axiosRequest from './Backend.js';
+import axiosRequest from 'Backend.js';
 
-import { VotingTable, WelcomeHeader } from './Sponsor.js';
-import Table from './Table.js';
-import SmallerParentheses from './SmallerParentheses.js';
+import { VotingTable, WelcomeHeader } from 'Sponsor.js';
+import Table from 'Table.js';
+import SmallerParentheses from 'SmallerParentheses.js';
 
-import './components/Card.css';
-import './SliderOption.css';
-import { sortByTableNumber } from './helpers.js';
+import 'components/Card.css';
+import 'SliderOption.css';
+import { sortByTableNumber } from 'helpers.js';
 
 class SearchandFilter extends Component {
 

--- a/expo/src/SiteWrapper.js
+++ b/expo/src/SiteWrapper.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import hackathon_logo from './customize/imgs/hackathon-logo.svg'
-import './SiteWrapper.css';
+import hackathon_logo from 'customize/imgs/hackathon-logo.svg'
+import 'SiteWrapper.css';
 
 /* Header / constant app features */
 

--- a/expo/src/SliderOption.css
+++ b/expo/src/SliderOption.css
@@ -1,5 +1,5 @@
 
-@import url('./customize/customize.css');
+@import url('customize/customize.css');
 
 .toggle {
   margin-top: 20px;

--- a/expo/src/Sponsor.css
+++ b/expo/src/Sponsor.css
@@ -1,5 +1,5 @@
 
-@import url('./customize/customize.css');
+@import url('customize/customize.css');
 /* Hide default checkbox */
 #Sponsor input[type=checkbox] {
   display: none;

--- a/expo/src/Sponsor.js
+++ b/expo/src/Sponsor.js
@@ -1,21 +1,21 @@
 import React, { Component, Fragment } from 'react';
-import axiosRequest from './Backend.js';
+import axiosRequest from 'Backend.js';
 
-import { FontAwesomeIcon } from '../node_modules/@fortawesome/react-fontawesome';
-import Error from './Error.js';
-import SearchandFilter from './SearchandFilter.js';
-import SiteWrapper from './SiteWrapper.js';
-import Table from './Table.js';
-import customize from './customize/customize';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Error from 'Error.js';
+import SearchandFilter from 'SearchandFilter.js';
+import SiteWrapper from 'SiteWrapper.js';
+import Table from 'Table.js';
+import customize from 'customize/customize';
 
-import './App.css';
-import './Sponsor.css';
-import './CircleCheck.css';
+import 'App.css';
+import 'Sponsor.css';
+import 'CircleCheck.css';
 
-import { faCircle } from '../node_modules/@fortawesome/fontawesome-free-regular';
-import { faCircle as faCircleSolid } from '../node_modules/@fortawesome/fontawesome-free-solid';
-import { faCheck, faExclamationTriangle, faTimesCircle, faClipboardList } from '../node_modules/@fortawesome/fontawesome-free-solid';
-import { library } from '../node_modules/@fortawesome/fontawesome-svg-core';
+import { faCircle } from '@fortawesome/fontawesome-free-regular';
+import { faCircle as faCircleSolid } from '@fortawesome/fontawesome-free-solid';
+import { faCheck, faExclamationTriangle, faTimesCircle, faClipboardList } from '@fortawesome/fontawesome-free-solid';
+import { library } from '@fortawesome/fontawesome-svg-core';
 library.add(faTimesCircle);
 library.add(faCircle);
 library.add(faCheck);

--- a/expo/src/SponsorLogin.js
+++ b/expo/src/SponsorLogin.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
-import axiosRequest from './Backend.js';
+import axiosRequest from 'Backend.js';
 
-import Error from './Error.js';
-import Login from './Login.js';
-import SiteWrapper from './SiteWrapper.js';
-import customize from './customize/customize';
+import Error from 'Error.js';
+import Login from 'Login.js';
+import SiteWrapper from 'SiteWrapper.js';
+import customize from 'customize/customize';
 
-import './App.css';
+import 'App.css';
 
 const errorText = "Invalid login code! Please see a member of the "
   + customize.hackathon_name + " staff if you don't know your access "

--- a/expo/src/Table.css
+++ b/expo/src/Table.css
@@ -1,4 +1,4 @@
-@import url('./customize/customize.css');
+@import url('customize/customize.css');
 
 /* Remove Default Link Style */
 #Home .link, #Sponsor .link,

--- a/expo/src/Table.js
+++ b/expo/src/Table.js
@@ -1,20 +1,20 @@
 import React, { Component, Fragment } from 'react';
 
-import { FontAwesomeIcon } from '../node_modules/@fortawesome/react-fontawesome';
-import WinnerBadge from './customize/imgs/winner_ribbon.png';
-import SmallerParentheses from './SmallerParentheses.js';
-import { SubmitModal } from './Sponsor.js';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import WinnerBadge from 'customize/imgs/winner_ribbon.png';
+import SmallerParentheses from 'SmallerParentheses.js';
+import { SubmitModal } from 'Sponsor.js';
 
-import '../node_modules/bootstrap/dist/css/bootstrap.min.css';
-import './App.css';
-import './Table.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'App.css';
+import 'Table.css';
 
-import './customize/customize';
-import { faSquare } from '../node_modules/@fortawesome/fontawesome-free-regular';
-import { faCheckSquare } from '../node_modules/@fortawesome/fontawesome-free-solid';
-import { library } from '../node_modules/@fortawesome/fontawesome-svg-core';
-import { faExclamationCircle } from '../node_modules/@fortawesome/fontawesome-free-solid';
-import customize from './customize/customize';
+import 'customize/customize';
+import { faSquare } from '@fortawesome/fontawesome-free-regular';
+import { faCheckSquare } from '@fortawesome/fontawesome-free-solid';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faExclamationCircle } from '@fortawesome/fontawesome-free-solid';
+import customize from 'customize/customize';
 library.add(faCheckSquare);
 library.add(faSquare);
 

--- a/expo/src/admin/AdminProject.js
+++ b/expo/src/admin/AdminProject.js
@@ -1,20 +1,19 @@
 import React, { Component } from "react";
-import axiosRequest from "../Backend.js";
+import axiosRequest from "Backend.js";
 
-import CreateProjectModal from "./CreateProjectModal";
+import CreateProjectModal from "admin/CreateProjectModal";
+import EditProjectModal from "admin/EditProjectModal";
+import WarningModal from "admin/WarningModal";
 
-import EditProjectModal from "./EditProjectModal";
-import WarningModal from "./WarningModal";
-
-import "../Admin.css";
-import "../App.css";
+import "Admin.css";
+import "App.css";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import SmallerParentheses from "../SmallerParentheses.js";
+import SmallerParentheses from "admin/SmallerParentheses.js";
 
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faSquare } from "../../node_modules/@fortawesome/fontawesome-free-regular";
-import { faCaretDown, faCaretUp, faCheckSquare, faUpload } from "../../node_modules/@fortawesome/fontawesome-free-solid";
+import { faSquare } from "@fortawesome/fontawesome-free-regular";
+import { faCaretDown, faCaretUp, faCheckSquare, faUpload } from "@fortawesome/fontawesome-free-solid";
 library.add(faUpload);
 library.add(faCaretDown);
 library.add(faCaretUp);
@@ -41,7 +40,7 @@ class ProjectModule extends Component {
         viewable: true,
       };
     }
-  
+
     createChallengesToCompanyMap(challenges_obj) {
       const allChallengesMapping = {};
       for (let company in challenges_obj) {
@@ -51,7 +50,7 @@ class ProjectModule extends Component {
       }
       return allChallengesMapping;
     }
-  
+
     createAllChallenges(obj) {
       let allChallenges = [];
       for (let key in obj) {
@@ -70,7 +69,7 @@ class ProjectModule extends Component {
       // })
       return allChallenges;
     }
-  
+
     sortData() {
       let data = this.props.projects;
       let finalProjectsData = [];
@@ -93,13 +92,13 @@ class ProjectModule extends Component {
       });
       return finalProjectsData;
     }
-  
+
     onUploadCSVSubmitForm(e) {
       e.preventDefault();
-  
+
       const data = new FormData();
       data.append("projects_csv", this.projects_csv.files[0]);
-  
+
       if (this.projects_csv.files[0] == null) {
         this.setState({
           uploadStatus: "Please select a file before hitting upload!",
@@ -121,17 +120,17 @@ class ProjectModule extends Component {
           });
       }
     }
-  
+
     handleInputChange(event) {
       const target = event.target;
       const value = target.type === "checkbox" ? target.checked : target.value;
       const name = target.name;
-  
+
       this.setState({
         [name]: value,
       });
     }
-  
+
     onAutoAssignTableNumbers(e) {
       e.preventDefault();
       if (this.state.tableAssignmentSchema == "") {
@@ -172,7 +171,7 @@ class ProjectModule extends Component {
           });
         });
     }
-  
+
     onRemoveAllTableAssignments(e) {
       e.preventDefault();
       if (window.confirm("Are you sure you want to remove ALL table assignments from your database?")) {
@@ -193,7 +192,7 @@ class ProjectModule extends Component {
           });
       }
     }
-  
+
     deleteAllProjects() {
       if (window.confirm("Are you sure you want to remove ALL projects from your database?")) {
         if (window.confirm("This action is not reversable.")) {
@@ -204,7 +203,7 @@ class ProjectModule extends Component {
         }
       }
     }
-  
+
     renderEditProjectModal = (elt, index, allChallenges, challengesToCompanyMap) => {
       return (
         <EditProjectModal
@@ -222,7 +221,7 @@ class ProjectModule extends Component {
         />
       );
     }
-  
+
     toggleView() {
       if (this.state.viewable) {
         this.setState({
@@ -236,7 +235,7 @@ class ProjectModule extends Component {
         document.getElementById("project-content").style.display = "block";
       }
     }
-  
+
     render() {
       let filteredProjects = this.sortData();
       let allChallenges = this.createAllChallenges(this.props.challenges);
@@ -248,7 +247,7 @@ class ProjectModule extends Component {
             elt.table_number.toUpperCase().includes(upperCaseTextSearch);
         });
       }
-  
+
       return (
         <div className="card">
           <div className="card-header">
@@ -263,7 +262,7 @@ class ProjectModule extends Component {
               </span>
             </div>
           </div>
-  
+
           <div className="card-body" id="project-content">
             <h5>Seed Database</h5>
             <form
@@ -286,10 +285,10 @@ class ProjectModule extends Component {
                 </div>
               }
             </form>
-  
+
             <br />
             <br />
-  
+
             <h5>Auto Assign Table Numbers</h5>
             <form
               method="post"
@@ -354,10 +353,10 @@ class ProjectModule extends Component {
                 </div>
               }
             </form>
-  
+
             <br />
             <br />
-  
+
             <h5>Projects <SmallerParentheses font_size="15px">{filteredProjects.length}</SmallerParentheses></h5>
             <CreateProjectModal
               createID="modalCreateProject"

--- a/expo/src/admin/AdminSponsor.js
+++ b/expo/src/admin/AdminSponsor.js
@@ -1,19 +1,19 @@
 import React, { Component } from "react";
-import axiosRequest from "../Backend.js";
+import axiosRequest from "Backend.js";
 
-import CreateChallengeModal from "./CreateChallengeModal";
-import CreateSponsorModal from "./CreateSponsorModal";
-import EditChallengeModal from "./EditChallengeModal";
-import EditSponsorModal from "./EditSponsorModal";
-import WarningModal from "./WarningModal";
-import SubmitInputModal from "../components/SubmitInputModal";
+import CreateChallengeModal from "admin/CreateChallengeModal";
+import CreateSponsorModal from "admin/CreateSponsorModal";
+import EditChallengeModal from "admin/EditChallengeModal";
+import EditSponsorModal from "admin/EditSponsorModal";
+import WarningModal from "admin/WarningModal";
+import SubmitInputModal from "components/SubmitInputModal";
 
-import "../Admin.css";
-import "../App.css";
+import "Admin.css";
+import "App.css";
 
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faSquare } from "../../node_modules/@fortawesome/fontawesome-free-regular";
-import { faCaretDown, faCaretUp, faCheckSquare, faUpload } from "../../node_modules/@fortawesome/fontawesome-free-solid";
+import { faSquare } from "@fortawesome/fontawesome-free-regular";
+import { faCaretDown, faCaretUp, faCheckSquare, faUpload } from "@fortawesome/fontawesome-free-solid";
 library.add(faUpload);
 library.add(faCaretDown);
 library.add(faCaretUp);
@@ -31,7 +31,7 @@ class SponsorModule extends Component {
         viewable: true,
       };
     }
-  
+
     loadCompanies() {
       axiosRequest.get("api/companies")
         .then((sponsors) => {
@@ -40,7 +40,7 @@ class SponsorModule extends Component {
           });
         });
     }
-  
+
     toggleView() {
       if (this.state.viewable) {
         this.setState({
@@ -54,7 +54,7 @@ class SponsorModule extends Component {
         document.getElementById("sponsor-content").style.display = "block";
       }
     }
-  
+
     deleteAllSponsors() {
       if (window.confirm("Are you sure you want to remove ALL sponsors from your database?")) {
         if (window.confirm("This action is not reversable.")) {
@@ -65,7 +65,7 @@ class SponsorModule extends Component {
         }
       }
     }
-  
+
     seedChallengesFromDevpost(devpostUrl) {
       // Determine inputted URL or default server Devpost URL
       const params = devpostUrl == "" ? {} : { "devpostUrl": devpostUrl };
@@ -74,12 +74,12 @@ class SponsorModule extends Component {
           this.loadCompanies();
         });
     }
-  
+
     // Pull data for sponsor list
     componentWillMount() {
       this.loadCompanies();
     }
-  
+
     render() {
       // Compress list by access_code to suit view
       let compressedSponsors = [];
@@ -91,7 +91,7 @@ class SponsorModule extends Component {
             codeSeen = true;
           }
         });
-  
+
         if (codeSeen == false) {
           // Set new item
           compressedSponsors.push(
@@ -103,7 +103,7 @@ class SponsorModule extends Component {
             },
           );
         }
-  
+
         // Add challenge to corresponding sponsor
         let current_sponsor = null;
         compressedSponsors.forEach((sponsor) => {
@@ -118,16 +118,16 @@ class SponsorModule extends Component {
             num_winners: elt.num_winners,
           });
         }
-  
+
       });
-  
+
       // Prepare sponsor list against filter (including sponsor name and challenges)
       let filteredSponsors = compressedSponsors;
       if (this.state.textSearch != "" && this.state.textSearch != undefined) {
         filteredSponsors = filteredSponsors.filter(elt => {
-  
+
           let casedTextSearch = this.state.textSearch.toUpperCase();
-  
+
           let chalSearch = false;
           elt.challenges.forEach(chal => {
             if (chal.challenge.toUpperCase().includes(casedTextSearch)) {
@@ -138,12 +138,12 @@ class SponsorModule extends Component {
             || chalSearch;
         });
       }
-  
+
       // Sort Sponsors
       filteredSponsors.sort((s1, s2) => {
         return (s1.company_name).localeCompare(s2.company_name);
       });
-  
+
       return (
         <div className="card">
           <div className="card-header">
@@ -230,7 +230,7 @@ class SponsorModule extends Component {
                           </button>
                       </span>
                     </div>
-  
+
                     <div>
                       <CreateChallengeModal
                         createID={"modalCreateChallenge" + key.toString()}
@@ -247,7 +247,7 @@ class SponsorModule extends Component {
                         Create Challenge
                             </button>
                     </div>
-  
+
                     {elt.challenges.map((challenge, i) => {
                       return (
                         <div>

--- a/expo/src/admin/AdminWinner.js
+++ b/expo/src/admin/AdminWinner.js
@@ -1,15 +1,15 @@
 import React, { Component } from "react";
-import axiosRequest from "../Backend.js";
+import axiosRequest from "Backend.js";
 
-import "../Admin.css";
-import "../App.css";
-import WinnerBadge from "../customize/imgs/winner_ribbon.png";
+import "Admin.css";
+import "App.css";
+import WinnerBadge from "customize/imgs/winner_ribbon.png";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faSquare } from "../../node_modules/@fortawesome/fontawesome-free-regular";
-import { faCaretDown, faCaretUp, faCheckSquare, faUpload } from "../../node_modules/@fortawesome/fontawesome-free-solid";
+import { faSquare } from "@fortawesome/fontawesome-free-regular";
+import { faCaretDown, faCaretUp, faCheckSquare, faUpload } from "@fortawesome/fontawesome-free-solid";
 library.add(faUpload);
 library.add(faCaretDown);
 library.add(faCaretUp);

--- a/expo/src/admin/ConfirmationButton.js
+++ b/expo/src/admin/ConfirmationButton.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 
-import '../App.css';
+import 'App.css';
 
 class ConfirmationButton extends Component {
-  
+
   render() {
     return (
       <div className="p-a-m">

--- a/expo/src/admin/CreateChallengeModal.js
+++ b/expo/src/admin/CreateChallengeModal.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
-import axiosRequest from '../Backend.js';
+import axiosRequest from 'Backend.js';
 
-import Error from '../Error.js';
+import Error from 'Error.js';
 
 
 const InvalidWinnerErr = <Error text="Invalid number of winners!

--- a/expo/src/admin/CreateProjectModal.js
+++ b/expo/src/admin/CreateProjectModal.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
-import axiosRequest from '../Backend.js';
+import axiosRequest from 'Backend.js';
 
-import Error from '../Error';
+import Error from 'Error';
 
 import { library } from '@fortawesome/fontawesome-svg-core';
-import { faCheck, faTimes } from '../../node_modules/@fortawesome/fontawesome-free-solid';
+import { faCheck, faTimes } from '@fortawesome/fontawesome-free-solid';
 library.add(faTimes);
 library.add(faCheck);
 

--- a/expo/src/admin/CreateSponsorModal.js
+++ b/expo/src/admin/CreateSponsorModal.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
-import axiosRequest from '../Backend.js';
+import axiosRequest from 'Backend.js';
 
-import Error from '../Error.js';
-import SmallerParentheses from '../SmallerParentheses.js';
+import Error from 'Error.js';
+import SmallerParentheses from 'SmallerParentheses.js';
 
 
 const InvalidAccessErr = <Error text="Invalid access code!

--- a/expo/src/admin/EditChallengeModal.js
+++ b/expo/src/admin/EditChallengeModal.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
-import axiosRequest from '../Backend.js';
+import axiosRequest from 'Backend.js';
 
-import Error from '../Error.js';
-import ConfirmationButton from './ConfirmationButton';
+import Error from 'Error.js';
+import ConfirmationButton from 'admin/ConfirmationButton';
 
-import '../App.css';
+import 'App.css';
 
 
 let InvalidWinnerErr = <Error text="Invalid number of winners!

--- a/expo/src/admin/EditProjectModal.js
+++ b/expo/src/admin/EditProjectModal.js
@@ -1,14 +1,14 @@
 import React, { Component } from 'react';
-import axiosRequest from '../Backend.js';
+import axiosRequest from 'Backend.js';
 
-import Error from '../Error';
-import Checkbox from './Checkbox';
-import ConfirmationButton from './ConfirmationButton';
+import Error from 'Error';
+import Checkbox from 'admin/Checkbox';
+import ConfirmationButton from 'admin/ConfirmationButton';
 
-import '../App.css';
+import 'App.css';
 
 import { library } from '@fortawesome/fontawesome-svg-core';
-import { faCheck, faTimes } from '../../node_modules/@fortawesome/fontawesome-free-solid';
+import { faCheck, faTimes } from '@fortawesome/fontawesome-free-solid';
 library.add(faTimes);
 library.add(faCheck);
 

--- a/expo/src/admin/EditSponsorModal.js
+++ b/expo/src/admin/EditSponsorModal.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
-import axiosRequest from '../Backend.js';
+import axiosRequest from 'Backend.js';
 
-import Error from '../Error.js';
-import ConfirmationButton from './ConfirmationButton';
+import Error from 'Error.js';
+import ConfirmationButton from 'admin/ConfirmationButton';
 
-import '../App.css';
+import 'App.css';
 
 
 const InvalidAccessErr = <Error text="Invalid access code!
@@ -64,7 +64,7 @@ class EditSponsorModal extends Component {
 
         let missingCompany = this.state.company_name === ''
           || this.state.company_name === undefined;
- 
+
         let valid = validAccess && !missingAccess && !missingCompany;
 
         let sponsor_id = this.props.sponsorID;

--- a/expo/src/admin/WarningModal.js
+++ b/expo/src/admin/WarningModal.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 
-import '../App.css';
+import 'App.css';
 
 class WarningModal extends Component {
-    
+
     render() {
         return (
             <div className="modal fade" id={this.props.modalId} role="dialog">

--- a/expo/src/components/Card.css
+++ b/expo/src/components/Card.css
@@ -1,5 +1,5 @@
 
-@import url('../customize/customize.css');
+@import url('/customize/customize.css');
 /* TODO decide on app-wide color scheme */
 
 .card {

--- a/expo/src/components/Card.js
+++ b/expo/src/components/Card.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 
-import '../../node_modules/bootstrap/dist/css/bootstrap.min.css';
-import './Card.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'components/Card.css';
 
 /**
  * @props

--- a/expo/src/components/GenericConfirmationModal.js
+++ b/expo/src/components/GenericConfirmationModal.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 
-import '../App.css';
+import 'App.css';
 
 /**
  * @props

--- a/expo/src/components/SubmitInputModal.js
+++ b/expo/src/components/SubmitInputModal.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 
-import '../App.css';
+import 'App.css';
 
 /**
  * @props

--- a/expo/src/index.js
+++ b/expo/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import App from './App';
+import App from 'App';
 
 
 ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
In general, absolute imports are better to use - they're more clear, and tend to make refactoring/moving code much easier. This change converts all react imports to be absolute.