### PR TITLE
Add suport for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ api/analytics.log
 nginx/certbot/
 !nginx/certbot/.gitkeep
 api/.mypy_cache/
+.pytest_cache
+pyvenv.cfg

--- a/api/README.md
+++ b/api/README.md
@@ -91,7 +91,7 @@ If you want to deploy to AWS you can follow these steps.
 1. Start a new EC2 instance. When choosing an image we recommend Ubuntu Server 18.04.
 2. Choose what size instance you want.
 3. Most of the other defaults will be ok to keep, however you will want to configure your security group to have port 80 and 443 open. SSH port should already be configured.
-   
+
    | Type | Protocol | Port Range | Source |
    | --- | --- | --- | --- |
    | HTTPS | TCP | 443 | Anywhere |
@@ -105,4 +105,8 @@ If you want to deploy to AWS you can follow these steps.
 ---
 
 # Testing
-[Coming soon]
+We use Pytest. From the root directory (one up from here), you can run
+
+`sudo docker-compose -f docker-compose-test.yml up --abort-on-container-exit`
+
+To run all the tests in a docker image.

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -21,3 +21,4 @@ urllib3==1.23
 Werkzeug==0.14.1
 mypy==0.720
 mypy-extensions==0.4.1
+pytest==5.2.0

--- a/api/server_test.py
+++ b/api/server_test.py
@@ -1,0 +1,5 @@
+import pytest
+from server import app
+
+def test_empty():
+    return True

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,24 @@
+version: '3'
+
+services:
+    db:
+        image: mongo
+        command: [--auth]
+        environment:
+            MONGO_INITDB_ROOT_USERNAME: admin
+            MONGO_INITDB_ROOT_PASSWORD: password
+            MONGO_INITDB_DATABASE: expo-testing
+        ports:
+            - "27017:27017"
+    test:
+        build:
+            context: ./api
+        volumes:
+            - .:/var/www/webapps/hackathon-expo-app/api
+        depends_on:
+            - db
+        ports:
+            - "8000:8000"
+        links:
+            - db:db
+        command: pytest


### PR DESCRIPTION
Add support (python lib, docker-compose config) to enable server testing

Related: #110