### PR TITLE
Add time estimate for judging for sponsors

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-From python:3
+From python:3.7
 
 ADD . /app
 

--- a/api/config.ex.py
+++ b/api/config.ex.py
@@ -4,5 +4,7 @@ MONGO_HOST = 'uri-to-connect-to-your-db-including-username-and-password'  # e.g.
 ADMIN_ACCESS_CODE = 'super-secret-admin-access-code-here'                 # Used to log into Godmode dashboard
 SECRET_KEY = 'some-super-secret-string-used-for-flask-sessions'           # A long string of random characters
 
+EXPO_LENGTH = 60 # Total length of the expo (in minutes). Used for computing time per table for sponsors.
+
 # If you aren't allowing this option for hackers, replace the string with the python None variable
 CUSTOM_DEVPOST_STAY_AT_TABLE_QUESTION = 'Exact string of the question configured in Devpost for checking which table a hack is currently at (if it must stay at that current table for expo).'

--- a/api/server.py
+++ b/api/server.py
@@ -192,6 +192,11 @@ def get_is_published_flag():
     logged_message(f'endpoint = /api/is_published_status, method = GET, params = NONE, type = public')
     return str(is_published)
 
+@app.route('/api/expo_length', methods=['GET'])
+def get_expo_length():
+    logged_message(f'endpoint = /api/expo_length, method = GET, params = NONE, type = public')
+    return str(current_app.config['EXPO_LENGTH'])
+
 
 # Admin routes #################################################################
 # All endpoints under the Admin routes should require admin authorization.

--- a/expo/src/JudgingTime.js
+++ b/expo/src/JudgingTime.js
@@ -9,17 +9,22 @@ import React, {useState} from "react";
 
 export default function JudgingTimes(props) {
     const [judges, setJudges] = useState(1);
+    const [endTime, setEndTime] = useState(10);
 
     if (props.count === 0) {
         return "You have no projects to judge."
     }
 
     const plural = judges === 1 ? "judge" : "judges";
-    const time = (props.time / props.count) * judges;
+    const time = ((props.time - endTime) / props.count) * judges;
 
     return (
     <div className="card">
         You have {props.count} projects to judge in {props.time} minutes. <br/>
-        <div className="nowrap">Given <input className="inline-numinput" type="number" id="numJudges" name="judges" min="1" value={judges} onChange={(e) => {setJudges(parseInt(e.target.value))}} /> {plural}, each judge can spend about {time.toFixed(1)} minutes per hack.</div>
+        <div className="nowrap">
+            Given
+                <input className="inline-numinput" type="number" id="numJudges" name="judges" min="1" value={judges} onChange={(e) => {setJudges(parseInt(e.target.value))}} /> {plural}, and
+                <input className="inline-numinput" type="number" id="endTime" name="selectionTime" min="1" value={endTime} onChange={(e) => {setEndTime(parseInt(e.target.value))}} /> minutes at the end to select a winner, <br/>
+            each judge can spend about {time.toFixed(1)} minutes per hack.</div>
     </div>);
 }

--- a/expo/src/JudgingTime.js
+++ b/expo/src/JudgingTime.js
@@ -1,0 +1,25 @@
+import React, {useState} from "react";
+
+/**
+ *
+ * @props
+ * time - Total expo length
+ * count - Total number of projects
+ */
+
+export default function JudgingTimes(props) {
+    const [judges, setJudges] = useState(1);
+
+    if (props.count === 0) {
+        return "You have no projects to judge."
+    }
+
+    const plural = judges === 1 ? "judge" : "judges";
+    const time = (props.time / props.count) * judges;
+
+    return (
+    <div className="card">
+        You have {props.count} projects to judge in {props.time} minutes. <br/>
+        <div className="nowrap">Given <input className="inline-numinput" type="number" id="numJudges" name="judges" min="1" value={judges} onChange={(e) => {setJudges(parseInt(e.target.value))}} /> {plural}, each judge can spend about {time.toFixed(1)} minutes per hack.</div>
+    </div>);
+}

--- a/expo/src/JudgingTime.js
+++ b/expo/src/JudgingTime.js
@@ -24,7 +24,7 @@ export default function JudgingTimes(props) {
         <div className="nowrap">
             Given
                 <input className="inline-numinput" type="number" id="numJudges" name="judges" min="1" value={judges} onChange={(e) => {setJudges(parseInt(e.target.value))}} /> {plural}, and
-                <input className="inline-numinput" type="number" id="endTime" name="selectionTime" min="1" value={endTime} onChange={(e) => {setEndTime(parseInt(e.target.value))}} /> minutes at the end to select a winner, <br/>
+                <input className="inline-numinput" type="number" id="endTime" name="selectionTime" min="1" value={endTime} onChange={(e) => {setEndTime(parseInt(e.target.value))}} /> minutes of buffer time, <br/>
             each judge can spend about {time.toFixed(1)} minutes per hack.</div>
     </div>);
 }

--- a/expo/src/SearchandFilter.js
+++ b/expo/src/SearchandFilter.js
@@ -9,6 +9,8 @@ import 'components/Card.css';
 import 'SliderOption.css';
 import { sortByTableNumber } from 'helpers.js';
 
+import JudgingTimes from './JudgingTime';
+
 class SearchandFilter extends Component {
 
   constructor(props) {
@@ -24,7 +26,9 @@ class SearchandFilter extends Component {
       workingdata: [],
       width: window.innerWidth,
       winnersRevealed: false,
-      expoIsPublished: false
+      expoIsPublished: false,
+      expoLength: 0,
+      totalCount: 0,
     }
     this.handleChange = this.handleChange.bind(this);
     this.handleToggle = this.handleToggle.bind(this);
@@ -55,6 +59,10 @@ class SearchandFilter extends Component {
               challenges: challenge_data,
               workingdata: this.setSponsorWorkingData(project_data['projects'], challenge_data),
               isLoadingData: false,
+            }, () => {
+              this.setState({
+                totalCount: this.state.workingdata.length,
+              })
             });
           });
         this.setState({
@@ -62,6 +70,13 @@ class SearchandFilter extends Component {
           expoIsPublished: project_data['is_published']
         });
       });
+
+      axiosRequest.get("api/expo_length")
+      .then((length) => {
+        this.setState({
+          expoLength: parseInt(length)
+        })
+      })
 
     this.updateDimensions();
     window.addEventListener("resize", this.updateDimensions);
@@ -262,6 +277,13 @@ class SearchandFilter extends Component {
       <Fragment></Fragment>
     );
 
+    let judging_times = (this.props.origin === "sponsor" ?
+      <div class="row">
+        <div class="col">
+          <JudgingTimes count={this.state.totalCount} time={this.state.expoLength} />
+        </div>
+      </div> : <Fragment></Fragment>);
+
     let toggle_style = (this.props.origin === "home" ? {
       display: "inline-block",
       textAlign: "left",
@@ -277,6 +299,7 @@ class SearchandFilter extends Component {
     return (
       <div>
         {welcome_header}
+        {judging_times}
         <div class="card">
           {this.props.origin === 'sponsor' ?
             <div class="card-header">

--- a/expo/src/Sponsor.css
+++ b/expo/src/Sponsor.css
@@ -175,3 +175,16 @@ div.bd-example-modal-sm button.button {
   color: var(--sponsor_fa_times_circle);
   font-size: 18px;
 }
+
+
+/*************************/
+
+.nowrap {
+  display: inline-block;
+  white-space:nowrap;
+  margin-top: 20px;
+}
+
+.inline-numinput {
+  max-width: 80px;
+}


### PR DESCRIPTION
* Sponsors now has a card that tells them based on the number of judges
they have, how many minutes they should spend at each table (taking expo
length and number of projects into account).

Resolves #93